### PR TITLE
Prevent jinja variable substitution when uploading inventory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
         state: 'directory'
         mode: '0700'
 
-    - name: Upload private
+    - name: Upload private key
       copy:
         src: '{{ vagrant_debops__ssh_keypair["private_key_file"] }}'
         dest: '{{ vagrant_debops__ssh_user_home }}/.ssh/{{ vagrant_debops__ssh_privkey_name }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,10 @@
 
     - name: Read Vagrant Ansible inventory
       set_fact:
-        vagrant_debops__fact_inventory: '{{ lookup("pipe", "cat " + inventory_dir + "/vagrant_ansible_inventory") }}'
+        # replace "{{" and "}}" with "[[" and "]]" to avoid substitution of
+        # variables which might not be defined in the context of the running
+        # playbook.
+        vagrant_debops__fact_inventory: '{{ lookup("pipe", "sed -E -e ''s|\{\{|[[|g'' -e ''s|}}|]]|g'' " + inventory_dir + "/vagrant_ansible_inventory") }}'
 
     - name: Upload Ansible inventory
       template:

--- a/templates/ansible/inventory/hosts.j2
+++ b/templates/ansible/inventory/hosts.j2
@@ -1,5 +1,6 @@
 {{ ansible_managed | comment }}
 {% for _line in vagrant_debops__fact_inventory.split("\n") %}
+{%   set _line = (_line | regex_replace("\[\[", "{{") | regex_replace("]]", "}}")) %}
 {%   if _line | search("ansible_ssh_private_key_file") %}
 {%     set _machine = _line.split(" ")[0] %}
 {{     (_line | regex_replace("ansible_ssh_private_key_file='.*'", "ansible_ssh_private_key_file='" + vagrant_debops__ssh_user_home + "/.ssh/" + _machine + "'")) +


### PR DESCRIPTION
This PR will prevent `<variable> is undefined` errors in the "Upload Ansible inventory" task.

Before this fix, it could happen, that when defining am Ansible variable which uses the jinja variable substitution (`{{ variable }}`)  in the `Vagrantfile` the task could fail. This because the inventory file generated by `vagrant` is read by a Jinja template and then re-written to match the context of the Vagrant machine. If this `variable` was undefined in the provisioning playbook run by `vagrant` the error mentioned above would be thrown which aborted the playbook run.